### PR TITLE
Some simple changes, one more controversial one

### DIFF
--- a/javascripts/jquery.rest_in_place.js
+++ b/javascripts/jquery.rest_in_place.js
@@ -11,7 +11,7 @@ RestInPlaceEditor.prototype = {
   
   activate : function() {
     this.oldValue = this.element.html();
-    this.element.addClass('riv-active');
+    this.element.addClass('rip-active');
     this.element.unbind('click', this.clickHandler)
     this.activateForm();
   },
@@ -19,7 +19,7 @@ RestInPlaceEditor.prototype = {
   abort : function() {
     this.element
       .html(this.oldValue)
-      .removeClass('riv-active')
+      .removeClass('rip-active')
       .bind('click', {editor: this}, this.clickHandler);
   },
   
@@ -33,7 +33,7 @@ RestInPlaceEditor.prototype = {
           "dataType" : 'json',
           "success"  : function(data){ editor.loadSuccessCallback(data) }
         });
-        editor.element.removeClass('riv-active');
+        editor.element.removeClass('rip-active');
       }
     });
     editor.element.html("saving...");


### PR DESCRIPTION
The first two commits in here are really straight-forward; they make it easier to include the rest_in_place into a large app. The added semicolons make sure that you can concatenate the JS with other JS files into a single download, and the switch from $ to jQuery makes it work in compatibility mode.

The third commit is a bit more interesting, however -- it's changes to the JS to add an "active" class to the containing element when the form is activated. That scratches an itch of mine so that I can style all of the in-place fields on my site.
