### PR TITLE
Support JSON response without root element

### DIFF
--- a/javascripts/jquery.rest_in_place.js
+++ b/javascripts/jquery.rest_in_place.js
@@ -112,6 +112,11 @@ RestInPlaceEditor.prototype = {
   loadSuccessCallback : function(data) {
     //jq14: data as JS object, not string.
     if (jQuery.fn.jquery < "1.4") data = eval('(' + data + ')' );
+    
+    // support data without root element
+    var value = data[this.objectName] ? data[this.objectName][this.attributeName] : data[this.attributeName];
+    this.element.html(value);
+    
     this.element.html(data[this.objectName][this.attributeName]);
     this.element.bind('click', {editor: this}, this.clickHandler);
     this.element.removeClass('rip-active');


### PR DESCRIPTION
In my app I return data without a root element:

{id: 123, title: ""}

I love the plugin and made this change for my personal use case, might be useful to you. (I still accept data with the root element specified).
