### PR TITLE
Changed path to javascript files if 3.1 rails version and removed mootols and prototype fomr install an uninstall files

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -1,13 +1,12 @@
 # Install hook code here
 puts "Copying files..."
-dir = "javascripts"
-%w[jquery.rest_in_place.js mootools.rest_in_place.js rest_in_place.js].each do |js_file|
-  dest_file = if (Rails::VERSION::STRING.to_f >= '3.1.0'.to_f)
-                File.join(::Rails.root, "vendor", "assets", dir, js_file)
-              else
-                File.join(::Rails.root, "public", dir, js_file)
-              end
-  src_file = File.join(File.dirname(__FILE__) , dir, js_file)
-  FileUtils.cp_r(src_file, dest_file)
-end
+dir       = "javascripts"
+file      = "jquery.rest_in_place.js"
+dest_file = if (Rails::VERSION::STRING.to_f >= '3.1.0'.to_f)
+              File.join(::Rails.root, "vendor", "assets", dir, file)
+            else
+              File.join(::Rails.root, "public", dir, file)
+            end
+src_file  = File.join(File.dirname(__FILE__) , dir, file)
+FileUtils.cp_r(src_file, dest_file)
 puts "Files copied - Installation complete!"

--- a/uninstall.rb
+++ b/uninstall.rb
@@ -1,12 +1,11 @@
 # Uninstall hook code here
 puts "Deleting files..."
-dir = "javascripts"
-%w[jquery.rest_in_place.js mootools.rest_in_place.js rest_in_place.js].each do |js_file|
-  dest_file = if (Rails::VERSION::STRING.to_f >= '3.1.0'.to_f)
-              	File.join(::Rails.root, "vendor", "assets", dir, js_file)
-              else
-                File.join(::Rails.root, "public", dir, js_file)
-              end
-  FileUtils.rm(dest_file)
-end
+dir       = "javascripts"
+file      = "jquery.rest_in_place.js"
+dest_file = if (Rails::VERSION::STRING.to_f >= '3.1.0'.to_f)
+              File.join(::Rails.root, "vendor", "assets", dir, file)
+            else
+              File.join(::Rails.root, "public", dir, file)
+            end
+FileUtils.rm(dest_file)
 puts "Files deleted - Uninstallation complete!"


### PR DESCRIPTION
I changed the path to javascript files to '/vendor/assets/javascripts' (recommended for rails 3.1) and removed mootols and prototype name files from install and uninstall files. 

Would be interesting merge this for the ones that are using rails (3.1).

Thanks
