### PR TITLE
Better error handling support

### DIFF
--- a/lib/assets/javascripts/rest_in_place/rest_in_place.coffee.erb
+++ b/lib/assets/javascripts/rest_in_place/rest_in_place.coffee.erb
@@ -173,7 +173,7 @@ class RestInPlaceEditor
 RestInPlaceEditor.forms = 
   "input" :
     activateForm : ->
-      @$element.html("""<form action="javascript:void(0)" style="display:inline;"><input type="text" value="#{$.trim(@oldValue)}" class="rest-in-place-#{@attributeName}"></form>""")
+      @$element.html("""<form action="javascript:void(0)" style="display:inline;"><input type="text" value="#{$.trim(@oldValue)}" class="rest-in-place-#{@attributeName}" maxlength="255"></form>""")
       @$element.find('input')[0].select()
       @$element.find("form").submit =>
         @update()


### PR DESCRIPTION
First commit adds support for the backend to answer with some JSON and be able to use it from the client

The second commit I didn't really want to pull request it, but I'm unable to get rid of it (this is my first pr :). It caps the length limit of an input text to 255 which is a nice default value often used in databases, and some sort of standard in my applications, but I could understand people not really needing it :)
