### PR TITLE
Use @$element.text() instead of @$element.html()

### DIFF
--- a/lib/assets/javascripts/rest_in_place/rest_in_place.js.coffee.erb
+++ b/lib/assets/javascripts/rest_in_place/rest_in_place.js.coffee.erb
@@ -160,7 +160,7 @@ class RestInPlaceEditor
     """<span class="rest-in-placeholder">#{@placeholder}</span>"""
 
   elementHTML: ->
-    value = @$element.html()
+    value = @$element.text()
     value = '' if value  == @placeholderHTML()
     value
 


### PR DESCRIPTION
Using .html() will convert an `&` into `&amp;`, and it will persist that way when it saves. Fixes #51
