### PR TITLE
Fix testapp with ruby-2.0, handle HTTP 204 No content

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -274,7 +274,7 @@ Testing
 =======
 
 The repository contains a `testapp` directory with a rails app that can be
-used to test REST in Place. Just head to `http://localhost:3000` to see it in
+used to test REST in Place. Run `bundle exec rake db:seed` and head to `http://localhost:3000` to see it in
 action.
 
 There's also an automated Jasmine spec suite running at

--- a/lib/assets/javascripts/rest_in_place/rest_in_place.js.coffee.erb
+++ b/lib/assets/javascripts/rest_in_place/rest_in_place.js.coffee.erb
@@ -37,13 +37,16 @@ class RestInPlaceEditor
   # value via GET
   update : ->
     @$element.trigger('update.rest-in-place')
+    @newValue = @getValue()
     updateRequest = @ajax
       type : "post"
       data : @requestData()
 
-    updateRequest.done (data) =>
+    updateRequest.done (data, textStatus, jqXHR) =>
       if data
         @loadSuccessCallback(data)
+      else if (jqXHR.status == 204)
+        @loadSuccessCallback(@newValue, true)
       else
         @loadViaGET()
 
@@ -167,8 +170,11 @@ class RestInPlaceEditor
   # ## Handlers ##############################################################
 
   # Handles the successful response from the server
-  loadSuccessCallback : (data) ->
-    @updateDisplayValue(@extractAttributeFromData(data))
+  loadSuccessCallback : (data, nocontent) ->
+    if nocontent
+      @updateDisplayValue(data)
+    else
+      @updateDisplayValue(@extractAttributeFromData(data))
     @$element.click(@clickHandler)
     @$element.removeClass('rip-active')
     @$element.trigger('success.rest-in-place', data)

--- a/testapp/Gemfile
+++ b/testapp/Gemfile
@@ -1,13 +1,13 @@
 source 'http://rubygems.org'
 
-gem 'rails', '3.1.3'
+gem 'rails', '~>3.2'
 gem "rest_in_place", :path => ".."
 
 gem 'sqlite3'
 gem 'json'
 
-gem 'sass-rails',   '~> 3.1.5'
-gem 'coffee-rails', '~> 3.1.1'
+gem 'sass-rails',   '~> 3.1'
+gem 'coffee-rails', '~> 3.1'
 gem 'uglifier', '>= 1.0.3'
 
 gem 'jquery-rails'

--- a/testapp/app/assets/javascripts/spec.coffee
+++ b/testapp/app/assets/javascripts/spec.coffee
@@ -100,13 +100,27 @@ describe "Server communication", ->
         options.dataType = "json"
         jqXHR
 
+    describe "when receiving HTTP 204 No Content", ->
+      newValue = 12
+      beforeEach ->
+        spyOn(rip, 'getValue').andCallFake () ->
+          newValue
+        spyOn(rip, 'loadSuccessCallback')
+        rip.update()
+
+      it "should abort", ->
+        jqXHR.status = 204
+        jqXHR.resolve('', '', jqXHR)
+        expect(rip.loadSuccessCallback).toHaveBeenCalledWith(newValue, true)
+
     describe "when receiving an empty body", ->
       beforeEach ->
         spyOn(rip, 'loadViaGET')
         rip.update()
 
       it "should load via get", ->
-        jqXHR.resolve()
+        jqXHR.status = 200
+        jqXHR.resolve('', '', jqXHR)
         expect(rip.loadViaGET).toHaveBeenCalled()
 
     describe "when receiving a body with data", ->


### PR DESCRIPTION
testapp fails to work with ruby-2.0 because of [sprockets issue](https://github.com/sstephenson/sprockets/issues/352), I've updated gems to minimal working versions.

Also rails-4 [responds with HTTP 204 No Content](https://github.com/rails/rails/issues/9862) if `respond_with` is used and object has been changed successfully. I've added this case handling and related test.