### PR TITLE
Ignoring data if it is the same as the placeholder

### DIFF
--- a/lib/assets/javascripts/rest_in_place/rest_in_place.js.coffee.erb
+++ b/lib/assets/javascripts/rest_in_place/rest_in_place.js.coffee.erb
@@ -129,7 +129,9 @@ class RestInPlaceEditor
   requestData : ->
     data = @getEncodedTokenAuthenticationParams()
     data["_method"] = 'put'
-    data["#{@objectName}[#{@attributeName}]"] = @getValue()
+    value = @getValue()
+    if value != @placeholder
+      data["#{@objectName}[#{@attributeName}]"] = @getValue()
     data
 
   # Extract CSRF token from metatags

--- a/lib/rest_in_place/version.rb
+++ b/lib/rest_in_place/version.rb
@@ -1,3 +1,3 @@
 module RestInPlace
-  VERSION = "2.5.0"
+  VERSION = "2.6.0"
 end


### PR DESCRIPTION
If the user has not changed the field (i.e. just clicked on it, then changed his mind but pressed ENTER), the data is not submitted.

In short, when requesting the data, if it is the same as the placeholder, does not submit the field to the server.

I've written a test case to cover this. The change didn't break any other spec, as well.
